### PR TITLE
fix parse_arg index out of range in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,9 +68,9 @@ func main() {
 	var z Limit
 
 	x.max = parse_arg(2)
-	if len(os.Args) >= 3 {
+	if len(os.Args) > 3 {
 		y.max = parse_arg(3)
-		if len(os.Args) >= 4 {
+		if len(os.Args) > 4 {
 			z.max = parse_arg(4)
 		} else {
 			z.max = x.max


### PR DESCRIPTION
Fix error introduced by d5b7df0d5d18b76d2aa1960e123f9209f7144b92, causing parameters to be parsed incorrectly when run (parameter one number ahead that is not existing was supplied to function parse_arg)
Full error message w/o command line, fixed by changing `>=` to `>` in lines 71 & 73 of file `main.go`:
```
panic: runtime error: index out of range

goroutine 1 [running]:
main.parse_arg(0x3, 0x3e8)
	/home/juozas/mtmapprune/main.go:42 +0x18c
main.main()
	/home/juozas/mtmapprune/main.go:72 +0xd4f
```

Ubuntu 18.0.4 building instructions are noted in #1, there simply running `make` doesn't work it for some reasons require `GOPATH=/usr/share/gocode` before `make` command to work correctly.