### PR TITLE
Set z.max to x.max when only x.max is supplied

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 		}
 	} else {
 		y.max = x.max
+		z.max = x.max
 	}
 
 	if len(os.Args) == 8 {


### PR DESCRIPTION
This fixes #5. Before, when only `max_x` is supplied to command line parameters, `max_z` would be set to `0` instead of value of `max_x`. Applying this patch whould make it behave more like it's described in `readme.md`.
Test run before applying the patch (copied from #5):
```
juozas@xubuntu:~/minetest$ cp worlds/test/map.sqlite worlds/test/map.sqlite.bak
juozas@xubuntu:~/minetest$ ~/mtmapprune/mtmapprune worlds/test/map.sqlite 1024
2019/05/19 17:47:41 Collecting blocks
2019/05/19 17:47:41 Deleting blocks
2019/05/19 17:47:44 Vaccuuming database
2019/05/19 17:47:44 Removed 88802 of 91073 blocks (limits: [-1024, -1024, 0]-[1024, 1024, 0])
```
Test run after applying the patch:
```
juozas@xubuntu:~/minetest$ cp worlds/test/map.sqlite.bak worlds/test/map.sqlite
juozas@xubuntu:~/minetest$ ~/mtmapprune/mtmapprune worlds/test/map.sqlite 1024
2019/05/19 19:12:19 Collecting blocks
2019/05/19 19:12:19 Deleting blocks
2019/05/19 19:12:20 Vaccuuming database
2019/05/19 19:12:21 Removed 8361 of 91073 blocks (limits: [-1024, -1024, -1024]-[1024, 1024, 1024])
```